### PR TITLE
feat: add decision node component

### DIFF
--- a/components/flow/FlowBuilder.tsx
+++ b/components/flow/FlowBuilder.tsx
@@ -18,8 +18,10 @@ import 'reactflow/dist/style.css';
 import { Sidebar } from './Sidebar';
 import { StartNode } from './nodes/StartNode';
 import { EndNode } from './nodes/EndNode';
+import { DecisionNode } from './nodes/DecisionNode';
+import { DecisionType } from '../../types/decision';
 
-const nodeTypes = { start: StartNode, end: EndNode };
+const nodeTypes = { start: StartNode, end: EndNode, decision: DecisionNode };
 
 export default function FlowBuilder() {
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
@@ -68,7 +70,10 @@ export default function FlowBuilder() {
         id,
         type,
         position,
-        data: { label: type === 'start' ? 'Início' : 'Fim' },
+        data: {
+          label: type === 'start' ? 'Início' : type === 'end' ? 'Fim' : 'Decisão',
+          decisionType: type === 'decision' ? DecisionType.RISCO : undefined,
+        },
       };
 
       setNodes((nds) => nds.concat(newNode));

--- a/components/flow/Sidebar.tsx
+++ b/components/flow/Sidebar.tsx
@@ -14,6 +14,13 @@ export function Sidebar() {
         Início
       </div>
       <div
+        onDragStart={(event) => onDragStart(event, 'decision')}
+        draggable
+        style={{ marginBottom: 10, padding: 8, border: '1px solid #555', borderRadius: 4, cursor: 'grab' }}
+      >
+        Decisão
+      </div>
+      <div
         onDragStart={(event) => onDragStart(event, 'end')}
         draggable
         style={{ padding: 8, border: '1px solid #555', borderRadius: 4, cursor: 'grab' }}

--- a/components/flow/nodes/DecisionNode.tsx
+++ b/components/flow/nodes/DecisionNode.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { Handle, NodeProps, Position } from 'reactflow';
+import { DecisionData, DecisionType, RiskLevel } from '../../../types/decision';
+
+export function DecisionNode({ data }: NodeProps<DecisionData>) {
+  const [type, setType] = useState<DecisionType>(data.decisionType || DecisionType.RISCO);
+  const [risk, setRisk] = useState<RiskLevel>(data.riskLevel || RiskLevel.MEDIO);
+  const [from, setFrom] = useState<number | undefined>(data.from);
+  const [to, setTo] = useState<number | undefined>(data.to);
+
+  return (
+    <div style={{ padding: 10, border: '1px solid #555', borderRadius: 4, background: '#e2e2f7' }}>
+      {data.label || 'Decisão'}
+      <div style={{ marginTop: 4 }}>
+        <select value={type} onChange={(e) => setType(e.target.value as DecisionType)}>
+          <option value={DecisionType.RISCO}>Tipo de risco</option>
+          <option value={DecisionType.ENDIVIDAMENTO}>Valor de endividamento</option>
+          <option value={DecisionType.PROPOSTA}>Valor da proposta</option>
+        </select>
+      </div>
+      {type === DecisionType.RISCO && (
+        <div style={{ marginTop: 4 }}>
+          <select value={risk} onChange={(e) => setRisk(e.target.value as RiskLevel)}>
+            <option value={RiskLevel.ALTO}>Alto</option>
+            <option value={RiskLevel.MEDIO}>Médio</option>
+            <option value={RiskLevel.BAIXO}>Baixo</option>
+          </select>
+        </div>
+      )}
+      {(type === DecisionType.ENDIVIDAMENTO || type === DecisionType.PROPOSTA) && (
+        <div style={{ marginTop: 4 }}>
+          <input
+            type="number"
+            placeholder="de"
+            value={from ?? ''}
+            onChange={(e) => setFrom(e.target.value ? Number(e.target.value) : undefined)}
+            style={{ width: 60, marginRight: 4 }}
+          />
+          <input
+            type="number"
+            placeholder="até"
+            value={to ?? ''}
+            onChange={(e) => setTo(e.target.value ? Number(e.target.value) : undefined)}
+            style={{ width: 60 }}
+          />
+        </div>
+      )}
+      <Handle type="target" position={Position.Top} />
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+}

--- a/types/decision.ts
+++ b/types/decision.ts
@@ -1,0 +1,19 @@
+export enum DecisionType {
+  RISCO = 'risco',
+  ENDIVIDAMENTO = 'endividamento',
+  PROPOSTA = 'proposta',
+}
+
+export enum RiskLevel {
+  ALTO = 'alto',
+  MEDIO = 'medio',
+  BAIXO = 'baixo',
+}
+
+export interface DecisionData {
+  label: string;
+  decisionType: DecisionType;
+  riskLevel?: RiskLevel;
+  from?: number;
+  to?: number;
+}


### PR DESCRIPTION
## Summary
- add decision node with selectable decision types and corresponding values
- expose decision node in flow builder and sidebar

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb3435ff90832f9de92721dd05dfe2