### PR TITLE
feat: add organize button for decision tree layout

### DIFF
--- a/components/flow/Sidebar.tsx
+++ b/components/flow/Sidebar.tsx
@@ -1,4 +1,8 @@
-export function Sidebar() {
+interface SidebarProps {
+  onOrganize: () => void;
+}
+
+export function Sidebar({ onOrganize }: SidebarProps) {
   const onDragStart = (event: React.DragEvent, nodeType: string) => {
     event.dataTransfer.setData('application/reactflow', nodeType);
     event.dataTransfer.effectAllowed = 'move';
@@ -6,6 +10,19 @@ export function Sidebar() {
 
   return (
     <aside style={{ width: 120, padding: 10, borderRight: '1px solid #ddd', background: '#f7f7f7' }}>
+      <button
+        onClick={onOrganize}
+        style={{
+          width: '100%',
+          marginBottom: 10,
+          padding: 8,
+          border: '1px solid #555',
+          borderRadius: 4,
+          cursor: 'pointer',
+        }}
+      >
+        Organizar
+      </button>
       <div
         onDragStart={(event) => onDragStart(event, 'start')}
         draggable


### PR DESCRIPTION
## Summary
- add organize button in sidebar to arrange nodes as decision tree
- implement layout algorithm to reposition flow nodes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb37e40c10832fa06563ed89e44d22