### PR TITLE
feat: add alçada selector component

### DIFF
--- a/components/flow/FlowBuilder.tsx
+++ b/components/flow/FlowBuilder.tsx
@@ -20,8 +20,9 @@ import { StartNode } from './nodes/StartNode';
 import { EndNode } from './nodes/EndNode';
 import { DecisionNode } from './nodes/DecisionNode';
 import { DecisionType } from '../../types/decision';
+import { AlcadaNode } from './nodes/AlcadaNode';
 
-const nodeTypes = { start: StartNode, end: EndNode, decision: DecisionNode };
+const nodeTypes = { start: StartNode, end: EndNode, decision: DecisionNode, alcada: AlcadaNode };
 
 export default function FlowBuilder() {
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
@@ -71,8 +72,16 @@ export default function FlowBuilder() {
         type,
         position,
         data: {
-          label: type === 'start' ? 'Início' : type === 'end' ? 'Fim' : 'Decisão',
+          label:
+            type === 'start'
+              ? 'Início'
+              : type === 'end'
+              ? 'Fim'
+              : type === 'decision'
+              ? 'Decisão'
+              : 'Alçada',
           decisionType: type === 'decision' ? DecisionType.RISCO : undefined,
+          levels: type === 'alcada' ? [] : undefined,
         },
       };
 

--- a/components/flow/Sidebar.tsx
+++ b/components/flow/Sidebar.tsx
@@ -21,6 +21,13 @@ export function Sidebar() {
         Decisão
       </div>
       <div
+        onDragStart={(event) => onDragStart(event, 'alcada')}
+        draggable
+        style={{ marginBottom: 10, padding: 8, border: '1px solid #555', borderRadius: 4, cursor: 'grab' }}
+      >
+        Alçada
+      </div>
+      <div
         onDragStart={(event) => onDragStart(event, 'end')}
         draggable
         style={{ padding: 8, border: '1px solid #555', borderRadius: 4, cursor: 'grab' }}

--- a/components/flow/nodes/AlcadaNode.tsx
+++ b/components/flow/nodes/AlcadaNode.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { Handle, NodeProps, Position } from 'reactflow';
+import { AlcadaTipo, ALCADA_LABELS, AlcadaData } from '../../../types/alcada';
+
+export function AlcadaNode({ data }: NodeProps<AlcadaData>) {
+  const [selecionado, setSelecionado] = useState<AlcadaTipo>(AlcadaTipo.ASSISTENTE_1);
+  const [lista, setLista] = useState<AlcadaTipo[]>(data.levels || []);
+
+  const adicionar = () => {
+    if (lista.length >= 5) return;
+    if (lista.includes(selecionado)) return;
+    setLista([...lista, selecionado]);
+  };
+
+  const mover = (from: number, to: number) => {
+    setLista((curr) => {
+      const copy = [...curr];
+      const item = copy[from];
+      copy.splice(from, 1);
+      copy.splice(to, 0, item);
+      return copy;
+    });
+  };
+
+  const remover = (index: number) => {
+    setLista((curr) => curr.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div style={{ padding: 10, border: '1px solid #555', borderRadius: 4, background: '#f0f0f0' }}>
+      <div style={{ marginBottom: 8 }}>
+        <select value={selecionado} onChange={(e) => setSelecionado(e.target.value as AlcadaTipo)}>
+          {Object.values(AlcadaTipo).map((tipo) => (
+            <option key={tipo} value={tipo}>
+              {ALCADA_LABELS[tipo]}
+            </option>
+          ))}
+        </select>
+        <button onClick={adicionar} disabled={lista.length >= 5} style={{ marginLeft: 4 }}>
+          Adicionar
+        </button>
+      </div>
+      <ul>
+        {lista.map((item, index) => (
+          <li key={item} style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
+            <span style={{ flex: 1 }}>
+              {index + 1}. {ALCADA_LABELS[item]}
+            </span>
+            <button onClick={() => mover(index, index - 1)} disabled={index === 0} style={{ marginRight: 4 }}>
+              ↑
+            </button>
+            <button
+              onClick={() => mover(index, index + 1)}
+              disabled={index === lista.length - 1}
+              style={{ marginRight: 4 }}
+            >
+              ↓
+            </button>
+            <button onClick={() => remover(index)}>✕</button>
+          </li>
+        ))}
+      </ul>
+      <Handle type="target" position={Position.Top} />
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+}

--- a/types/alcada.ts
+++ b/types/alcada.ts
@@ -1,0 +1,26 @@
+export enum AlcadaTipo {
+  ASSISTENTE_1 = 'assistente_1',
+  ASSISTENTE_2 = 'assistente_2',
+  ASSISTENTE_3 = 'assistente_3',
+  ANALISTA_1 = 'analista_1',
+  ANALISTA_2 = 'analista_2',
+  ANALISTA_3 = 'analista_3',
+  GERENTE_REGIONAL = 'gerente_regional',
+  GERENTE_SEDE = 'gerente_sede',
+}
+
+export const ALCADA_LABELS: Record<AlcadaTipo, string> = {
+  [AlcadaTipo.ASSISTENTE_1]: 'Assistente 1',
+  [AlcadaTipo.ASSISTENTE_2]: 'Assistente 2',
+  [AlcadaTipo.ASSISTENTE_3]: 'Assistente 3',
+  [AlcadaTipo.ANALISTA_1]: 'Analista 1',
+  [AlcadaTipo.ANALISTA_2]: 'Analista 2',
+  [AlcadaTipo.ANALISTA_3]: 'Analista 3',
+  [AlcadaTipo.GERENTE_REGIONAL]: 'Gerente Regional',
+  [AlcadaTipo.GERENTE_SEDE]: 'Gerente Sede',
+};
+
+export interface AlcadaData {
+  label: string;
+  levels: AlcadaTipo[];
+}


### PR DESCRIPTION
## Summary
- add Alçada component allowing selection and prioritization of approval levels
- integrate Alçada as draggable node in the flow builder
- define node data structure for approval levels

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb37435b5c832f803dd5d19ffeb325