### PR TITLE
Adjust node connection rules for flow builder

### DIFF
--- a/components/flow/FlowBuilder.tsx
+++ b/components/flow/FlowBuilder.tsx
@@ -35,11 +35,15 @@ export default function FlowBuilder() {
       const sourceNode = nodes.find((n) => n.id === params.source);
       const targetNode = nodes.find((n) => n.id === params.target);
 
-      if (sourceNode?.type === 'start' && edges.some((e) => e.source === sourceNode.id)) {
+      if (targetNode?.type === 'decision' && edges.some((e) => e.target === targetNode.id)) {
         return;
       }
 
-      if (targetNode?.type === 'end' && edges.some((e) => e.target === targetNode.id)) {
+      if (targetNode?.type === 'alcada' && edges.some((e) => e.target === targetNode.id)) {
+        return;
+      }
+
+      if (sourceNode?.type === 'alcada' && edges.some((e) => e.source === sourceNode.id)) {
         return;
       }
 
@@ -59,6 +63,9 @@ export default function FlowBuilder() {
 
       const type = event.dataTransfer.getData('application/reactflow');
       if (!type || !reactFlowInstance) return;
+
+      if (type === 'start' && nodes.some((n) => n.type === 'start')) return;
+      if (type === 'end' && nodes.some((n) => n.type === 'end')) return;
 
       const reactFlowBounds = reactFlowWrapper.current?.getBoundingClientRect();
       const position = reactFlowInstance.project({
@@ -88,7 +95,7 @@ export default function FlowBuilder() {
 
       setNodes((nds) => nds.concat(newNode));
     },
-    [reactFlowInstance, setNodes]
+    [reactFlowInstance, setNodes, nodes]
   );
 
   const organizeFlow = useCallback(() => {


### PR DESCRIPTION
## Summary
- allow start node to branch to multiple nodes and end node to collect multiple incoming edges
- restrict decision nodes to a single incoming edge and alçada nodes to one in/one out
- prevent adding more than one start or end node in the editor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb3b45bcfc832f86f6bcc390c6694c