### PR TITLE
feat: add json import/export and move minimap

### DIFF
--- a/components/flow/FlowBuilder.tsx
+++ b/components/flow/FlowBuilder.tsx
@@ -148,10 +148,32 @@ export default function FlowBuilder() {
     reactFlowInstance?.fitView();
   }, [nodes, edges, setNodes, reactFlowInstance]);
 
+  const saveFlow = useCallback(() => {
+    if (!reactFlowInstance) return;
+    const flow = reactFlowInstance.toObject();
+    const json = JSON.stringify(flow, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'fluxo.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [reactFlowInstance]);
+
+  const loadFlow = useCallback(
+    (flow: { nodes: Node[]; edges: Edge[] }) => {
+      if (!flow) return;
+      setNodes(flow.nodes || []);
+      setEdges(flow.edges || []);
+    },
+    [setNodes, setEdges]
+  );
+
   return (
     <ReactFlowProvider>
       <div style={{ display: 'flex', height: '100%' }}>
-        <Sidebar onOrganize={organizeFlow} />
+        <Sidebar onOrganize={organizeFlow} onSave={saveFlow} onLoad={loadFlow} />
         <div style={{ flex: 1, height: '100%' }} ref={reactFlowWrapper}>
           <ReactFlow
             nodes={nodes}
@@ -165,7 +187,7 @@ export default function FlowBuilder() {
             nodeTypes={nodeTypes}
             fitView
           >
-            <MiniMap style={{ left: 10, bottom: 10 }} />
+            <MiniMap style={{ right: 10, bottom: 10 }} />
             <Controls />
             <Background />
           </ReactFlow>

--- a/components/flow/Sidebar.tsx
+++ b/components/flow/Sidebar.tsx
@@ -1,11 +1,38 @@
+import React, { useRef } from 'react';
+import { Edge, Node } from 'reactflow';
+
 interface SidebarProps {
   onOrganize: () => void;
+  onSave: () => void;
+  onLoad: (flow: { nodes: Node[]; edges: Edge[] }) => void;
 }
 
-export function Sidebar({ onOrganize }: SidebarProps) {
+export function Sidebar({ onOrganize, onSave, onLoad }: SidebarProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   const onDragStart = (event: React.DragEvent, nodeType: string) => {
     event.dataTransfer.setData('application/reactflow', nodeType);
     event.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const text = e.target?.result as string;
+        const flow = JSON.parse(text);
+        onLoad(flow);
+      } catch (err) {
+        console.error('Invalid JSON', err);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const triggerFileSelect = () => {
+    fileInputRef.current?.click();
   };
 
   return (
@@ -23,6 +50,39 @@ export function Sidebar({ onOrganize }: SidebarProps) {
       >
         Organizar
       </button>
+      <button
+        onClick={onSave}
+        style={{
+          width: '100%',
+          marginBottom: 10,
+          padding: 8,
+          border: '1px solid #555',
+          borderRadius: 4,
+          cursor: 'pointer',
+        }}
+      >
+        Salvar JSON
+      </button>
+      <button
+        onClick={triggerFileSelect}
+        style={{
+          width: '100%',
+          marginBottom: 10,
+          padding: 8,
+          border: '1px solid #555',
+          borderRadius: 4,
+          cursor: 'pointer',
+        }}
+      >
+        Importar JSON
+      </button>
+      <input
+        type="file"
+        accept="application/json"
+        ref={fileInputRef}
+        onChange={handleFileChange}
+        style={{ display: 'none' }}
+      />
       <div
         onDragStart={(event) => onDragStart(event, 'start')}
         draggable


### PR DESCRIPTION
## Summary
- move React Flow minimap to the right
- add save/import JSON actions in sidebar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb42a50238832fac3582b580a1d67a