### PR TITLE
feat: enhance flow builder sidebar with icons

### DIFF
--- a/components/flow/Sidebar.tsx
+++ b/components/flow/Sidebar.tsx
@@ -1,5 +1,8 @@
 import React, { useRef } from 'react';
-import { Edge, Node } from 'reactflow';
+import type { Edge, Node } from 'reactflow';
+import { ListTree, Save, Upload, CirclePlay, GitBranch, Users, CircleStop } from 'lucide-react';
+import { SidebarButton } from './SidebarButton';
+import { SidebarNode } from './SidebarNode';
 
 interface SidebarProps {
   onOrganize: () => void;
@@ -9,11 +12,6 @@ interface SidebarProps {
 
 export function Sidebar({ onOrganize, onSave, onLoad }: SidebarProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const onDragStart = (event: React.DragEvent, nodeType: string) => {
-    event.dataTransfer.setData('application/reactflow', nodeType);
-    event.dataTransfer.effectAllowed = 'move';
-  };
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -36,81 +34,21 @@ export function Sidebar({ onOrganize, onSave, onLoad }: SidebarProps) {
   };
 
   return (
-    <aside style={{ width: 120, padding: 10, borderRight: '1px solid #ddd', background: '#f7f7f7' }}>
-      <button
-        onClick={onOrganize}
-        style={{
-          width: '100%',
-          marginBottom: 10,
-          padding: 8,
-          border: '1px solid #555',
-          borderRadius: 4,
-          cursor: 'pointer',
-        }}
-      >
-        Organizar
-      </button>
-      <button
-        onClick={onSave}
-        style={{
-          width: '100%',
-          marginBottom: 10,
-          padding: 8,
-          border: '1px solid #555',
-          borderRadius: 4,
-          cursor: 'pointer',
-        }}
-      >
-        Salvar JSON
-      </button>
-      <button
-        onClick={triggerFileSelect}
-        style={{
-          width: '100%',
-          marginBottom: 10,
-          padding: 8,
-          border: '1px solid #555',
-          borderRadius: 4,
-          cursor: 'pointer',
-        }}
-      >
-        Importar JSON
-      </button>
+    <aside className="w-40 p-3 border-r border-gray-300 bg-gray-50">
+      <SidebarButton label="Organizar" icon={ListTree} onClick={onOrganize} />
+      <SidebarButton label="Salvar JSON" icon={Save} onClick={onSave} />
+      <SidebarButton label="Importar JSON" icon={Upload} onClick={triggerFileSelect} />
       <input
         type="file"
         accept="application/json"
         ref={fileInputRef}
         onChange={handleFileChange}
-        style={{ display: 'none' }}
+        className="hidden"
       />
-      <div
-        onDragStart={(event) => onDragStart(event, 'start')}
-        draggable
-        style={{ marginBottom: 10, padding: 8, border: '1px solid #555', borderRadius: 4, cursor: 'grab' }}
-      >
-        Início
-      </div>
-      <div
-        onDragStart={(event) => onDragStart(event, 'decision')}
-        draggable
-        style={{ marginBottom: 10, padding: 8, border: '1px solid #555', borderRadius: 4, cursor: 'grab' }}
-      >
-        Decisão
-      </div>
-      <div
-        onDragStart={(event) => onDragStart(event, 'alcada')}
-        draggable
-        style={{ marginBottom: 10, padding: 8, border: '1px solid #555', borderRadius: 4, cursor: 'grab' }}
-      >
-        Alçada
-      </div>
-      <div
-        onDragStart={(event) => onDragStart(event, 'end')}
-        draggable
-        style={{ padding: 8, border: '1px solid #555', borderRadius: 4, cursor: 'grab' }}
-      >
-        Fim
-      </div>
+      <SidebarNode type="start" label="Início" icon={CirclePlay} />
+      <SidebarNode type="decision" label="Decisão" icon={GitBranch} />
+      <SidebarNode type="alcada" label="Alçada" icon={Users} />
+      <SidebarNode type="end" label="Fim" icon={CircleStop} />
     </aside>
   );
 }

--- a/components/flow/SidebarButton.tsx
+++ b/components/flow/SidebarButton.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+interface SidebarButtonProps {
+  label: string;
+  icon: LucideIcon;
+  onClick: () => void;
+}
+
+export function SidebarButton({ label, icon: Icon, onClick }: SidebarButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex w-full items-center gap-2 mb-2 px-2 py-1 border border-gray-600 rounded hover:bg-gray-100"
+    >
+      <Icon size={16} />
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/components/flow/SidebarNode.tsx
+++ b/components/flow/SidebarNode.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+interface SidebarNodeProps {
+  type: string;
+  label: string;
+  icon: LucideIcon;
+}
+
+export function SidebarNode({ type, label, icon: Icon }: SidebarNodeProps) {
+  const onDragStart = (event: React.DragEvent) => {
+    event.dataTransfer.setData('application/reactflow', type);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  return (
+    <div
+      draggable
+      onDragStart={onDragStart}
+      className="flex items-center gap-2 mb-2 px-2 py-1 border border-gray-600 rounded cursor-grab bg-white hover:bg-gray-50"
+    >
+      <Icon size={16} />
+      <span>{label}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- refactor flow builder sidebar with icon-based buttons and node items
- add reusable `SidebarButton` and `SidebarNode` components for better UX

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb44c167c4832fb68f67519587de70