### PR TITLE
feat: enhance map sidebar with icons and components

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,3 +6,37 @@ body {
   margin: 0;
   font-family: sans-serif;
 }
+
+.sidebar {
+  width: 150px;
+  padding: 10px;
+  border-right: 1px solid #ddd;
+  background: #f7f7f7;
+}
+
+.sidebar-button,
+.sidebar-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 10px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  background: #fff;
+  transition: background 0.2s;
+}
+
+.sidebar-button:hover,
+.sidebar-item:hover {
+  background: #eee;
+}
+
+.sidebar-button {
+  cursor: pointer;
+}
+
+.sidebar-item {
+  cursor: grab;
+}

--- a/components/flow/FlowBuilder.tsx
+++ b/components/flow/FlowBuilder.tsx
@@ -89,7 +89,6 @@ export default function FlowBuilder() {
                   : 'Alçada',
           decisionType: type === 'decision' ? DecisionType.RISCO : undefined,
           levels: type === 'alcada' ? [] : undefined,
-
         },
       };
 
@@ -190,7 +189,23 @@ export default function FlowBuilder() {
             nodeTypes={nodeTypes}
             fitView
           >
-            <MiniMap style={{ right: 10, bottom: 10 }} />
+            <MiniMap
+              style={{ right: 10, bottom: 10 }}
+              nodeColor={(n) => {
+                switch (n.type) {
+                  case 'start':
+                    return '#6ede87';
+                  case 'end':
+                    return '#ff6b6b';
+                  case 'decision':
+                    return '#ffd966';
+                  case 'alcada':
+                    return '#6ba5ff';
+                  default:
+                    return '#ccc';
+                }
+              }}
+            />
             <Controls />
             <Background />
           </ReactFlow>

--- a/components/flow/Sidebar.tsx
+++ b/components/flow/Sidebar.tsx
@@ -1,5 +1,8 @@
 import React, { useRef } from 'react';
 import { Edge, Node } from 'reactflow';
+import { SidebarButton } from './SidebarButton';
+import { SidebarNodeItem } from './SidebarNodeItem';
+import { Wand2, Save, Upload, Play, GitBranch, Shield, Flag } from 'lucide-react';
 
 interface SidebarProps {
   onOrganize: () => void;
@@ -36,46 +39,10 @@ export function Sidebar({ onOrganize, onSave, onLoad }: SidebarProps) {
   };
 
   return (
-    <aside style={{ width: 120, padding: 10, borderRight: '1px solid #ddd', background: '#f7f7f7' }}>
-      <button
-        onClick={onOrganize}
-        style={{
-          width: '100%',
-          marginBottom: 10,
-          padding: 8,
-          border: '1px solid #555',
-          borderRadius: 4,
-          cursor: 'pointer',
-        }}
-      >
-        Organizar
-      </button>
-      <button
-        onClick={onSave}
-        style={{
-          width: '100%',
-          marginBottom: 10,
-          padding: 8,
-          border: '1px solid #555',
-          borderRadius: 4,
-          cursor: 'pointer',
-        }}
-      >
-        Salvar JSON
-      </button>
-      <button
-        onClick={triggerFileSelect}
-        style={{
-          width: '100%',
-          marginBottom: 10,
-          padding: 8,
-          border: '1px solid #555',
-          borderRadius: 4,
-          cursor: 'pointer',
-        }}
-      >
-        Importar JSON
-      </button>
+    <aside className="sidebar">
+      <SidebarButton label="Organizar" icon={Wand2} onClick={onOrganize} />
+      <SidebarButton label="Salvar JSON" icon={Save} onClick={onSave} />
+      <SidebarButton label="Importar JSON" icon={Upload} onClick={triggerFileSelect} />
       <input
         type="file"
         accept="application/json"
@@ -83,34 +50,10 @@ export function Sidebar({ onOrganize, onSave, onLoad }: SidebarProps) {
         onChange={handleFileChange}
         style={{ display: 'none' }}
       />
-      <div
-        onDragStart={(event) => onDragStart(event, 'start')}
-        draggable
-        style={{ marginBottom: 10, padding: 8, border: '1px solid #555', borderRadius: 4, cursor: 'grab' }}
-      >
-        Início
-      </div>
-      <div
-        onDragStart={(event) => onDragStart(event, 'decision')}
-        draggable
-        style={{ marginBottom: 10, padding: 8, border: '1px solid #555', borderRadius: 4, cursor: 'grab' }}
-      >
-        Decisão
-      </div>
-      <div
-        onDragStart={(event) => onDragStart(event, 'alcada')}
-        draggable
-        style={{ marginBottom: 10, padding: 8, border: '1px solid #555', borderRadius: 4, cursor: 'grab' }}
-      >
-        Alçada
-      </div>
-      <div
-        onDragStart={(event) => onDragStart(event, 'end')}
-        draggable
-        style={{ padding: 8, border: '1px solid #555', borderRadius: 4, cursor: 'grab' }}
-      >
-        Fim
-      </div>
+      <SidebarNodeItem nodeType="start" label="Início" icon={Play} onDragStart={onDragStart} />
+      <SidebarNodeItem nodeType="decision" label="Decisão" icon={GitBranch} onDragStart={onDragStart} />
+      <SidebarNodeItem nodeType="alcada" label="Alçada" icon={Shield} onDragStart={onDragStart} />
+      <SidebarNodeItem nodeType="end" label="Fim" icon={Flag} onDragStart={onDragStart} />
     </aside>
   );
 }

--- a/components/flow/SidebarButton.tsx
+++ b/components/flow/SidebarButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+interface SidebarButtonProps {
+  label: string;
+  icon: LucideIcon;
+  onClick: () => void;
+}
+
+export function SidebarButton({ label, icon: Icon, onClick }: SidebarButtonProps) {
+  return (
+    <button className="sidebar-button" onClick={onClick}>
+      <Icon size={16} />
+      {label}
+    </button>
+  );
+}

--- a/components/flow/SidebarNodeItem.tsx
+++ b/components/flow/SidebarNodeItem.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+interface SidebarNodeItemProps {
+  nodeType: string;
+  label: string;
+  icon: LucideIcon;
+  onDragStart: (event: React.DragEvent, nodeType: string) => void;
+}
+
+export function SidebarNodeItem({ nodeType, label, icon: Icon, onDragStart }: SidebarNodeItemProps) {
+  return (
+    <div
+      className="sidebar-item"
+      draggable
+      onDragStart={(event) => onDragStart(event, nodeType)}
+    >
+      <Icon size={16} />
+      {label}
+    </div>
+  );
+}

--- a/components/flow/nodes/AlcadaNode.tsx
+++ b/components/flow/nodes/AlcadaNode.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Handle, NodeProps, Position } from 'reactflow';
 import { AlcadaTipo, ALCADA_LABELS, AlcadaData } from '../../../types/alcada';
+import { Shield } from 'lucide-react';
 
 export function AlcadaNode({ data }: NodeProps<AlcadaData>) {
   const [selecionado, setSelecionado] = useState<AlcadaTipo>(AlcadaTipo.ASSISTENTE_1);
@@ -27,7 +28,19 @@ export function AlcadaNode({ data }: NodeProps<AlcadaData>) {
   };
 
   return (
-    <div style={{ padding: 10, border: '1px solid #555', borderRadius: 4, background: '#f0f0f0' }}>
+    <div
+      style={{
+        padding: 10,
+        border: '1px solid #555',
+        borderRadius: 4,
+        background: '#f0f0f0',
+        position: 'relative',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginBottom: 8 }}>
+        <Shield size={16} />
+        {data.label || 'Alçada'}
+      </div>
       <div style={{ marginBottom: 8 }}>
         <select value={selecionado} onChange={(e) => setSelecionado(e.target.value as AlcadaTipo)}>
           {Object.values(AlcadaTipo).map((tipo) => (

--- a/components/flow/nodes/DecisionNode.tsx
+++ b/components/flow/nodes/DecisionNode.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Handle, NodeProps, Position } from 'reactflow';
 import { DecisionData, DecisionType, RiskLevel } from '../../../types/decision';
+import { GitBranch } from 'lucide-react';
 
 export function DecisionNode({ data }: NodeProps<DecisionData>) {
   const [type, setType] = useState<DecisionType>(data.decisionType || DecisionType.RISCO);
@@ -9,8 +10,19 @@ export function DecisionNode({ data }: NodeProps<DecisionData>) {
   const [to, setTo] = useState<number | undefined>(data.to);
 
   return (
-    <div style={{ padding: 10, border: '1px solid #555', borderRadius: 4, background: '#e2e2f7' }}>
-      {data.label || 'Decisão'}
+    <div
+      style={{
+        padding: 10,
+        border: '1px solid #555',
+        borderRadius: 4,
+        background: '#e2e2f7',
+        position: 'relative',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+        <GitBranch size={16} />
+        {data.label || 'Decisão'}
+      </div>
       <div style={{ marginTop: 4 }}>
         <select value={type} onChange={(e) => setType(e.target.value as DecisionType)}>
           <option value={DecisionType.RISCO}>Tipo de risco</option>

--- a/components/flow/nodes/EndNode.tsx
+++ b/components/flow/nodes/EndNode.tsx
@@ -1,8 +1,21 @@
 import { Handle, NodeProps, Position } from 'reactflow';
+import { Flag } from 'lucide-react';
 
 export function EndNode({ data }: NodeProps) {
   return (
-    <div style={{ padding: 10, border: '1px solid #555', borderRadius: 4, background: '#fde2e2' }}>
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 4,
+        padding: 10,
+        border: '1px solid #555',
+        borderRadius: 4,
+        background: '#fde2e2',
+        position: 'relative',
+      }}
+    >
+      <Flag size={16} />
       {data.label || 'Fim'}
       <Handle type="target" position={Position.Top} />
     </div>

--- a/components/flow/nodes/StartNode.tsx
+++ b/components/flow/nodes/StartNode.tsx
@@ -1,8 +1,21 @@
 import { Handle, NodeProps, Position } from 'reactflow';
+import { Play } from 'lucide-react';
 
 export function StartNode({ data }: NodeProps) {
   return (
-    <div style={{ padding: 10, border: '1px solid #555', borderRadius: 4, background: '#e2f7e1' }}>
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 4,
+        padding: 10,
+        border: '1px solid #555',
+        borderRadius: 4,
+        background: '#e2f7e1',
+        position: 'relative',
+      }}
+    >
+      <Play size={16} />
       {data.label || 'Início'}
       <Handle type="source" position={Position.Bottom} />
     </div>


### PR DESCRIPTION
## Summary
- redesign map sidebar using new `SidebarButton` and `SidebarNodeItem` components with Lucide icons
- add icons to flow nodes and color-coded minimap for clearer navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb4645fd40832fb5f37d2ae67c3ab2