### PR TITLE
Restrict decision node connections and add deletion controls

### DIFF
--- a/components/flow/FlowBuilder.tsx
+++ b/components/flow/FlowBuilder.tsx
@@ -43,6 +43,10 @@ export default function FlowBuilder() {
         return;
       }
 
+      if (sourceNode?.type === 'decision' && edges.some((e) => e.source === sourceNode.id)) {
+        return;
+      }
+
       if (sourceNode?.type === 'alcada' && edges.some((e) => e.source === sourceNode.id)) {
         return;
       }
@@ -172,10 +176,15 @@ export default function FlowBuilder() {
     [setNodes, setEdges]
   );
 
+  const deleteSelected = useCallback(() => {
+    setNodes((nds) => nds.filter((n) => !n.selected));
+    setEdges((eds) => eds.filter((e) => !e.selected));
+  }, [setNodes, setEdges]);
+
   return (
     <ReactFlowProvider>
       <div style={{ display: 'flex', height: '100%' }}>
-        <Sidebar onOrganize={organizeFlow} onSave={saveFlow} onLoad={loadFlow} />
+        <Sidebar onOrganize={organizeFlow} onSave={saveFlow} onLoad={loadFlow} onDelete={deleteSelected} />
         <div style={{ flex: 1, height: '100%' }} ref={reactFlowWrapper}>
           <ReactFlow
             nodes={nodes}
@@ -187,6 +196,7 @@ export default function FlowBuilder() {
             onDrop={onDrop}
             onDragOver={onDragOver}
             nodeTypes={nodeTypes}
+            deleteKeyCode={["Delete", "Backspace"]}
             fitView
           >
             <MiniMap

--- a/components/flow/Sidebar.tsx
+++ b/components/flow/Sidebar.tsx
@@ -2,15 +2,16 @@ import React, { useRef } from 'react';
 import { Edge, Node } from 'reactflow';
 import { SidebarButton } from './SidebarButton';
 import { SidebarNodeItem } from './SidebarNodeItem';
-import { Wand2, Save, Upload, Play, GitBranch, Shield, Flag } from 'lucide-react';
+import { Wand2, Save, Upload, Play, GitBranch, Shield, Flag, Trash } from 'lucide-react';
 
 interface SidebarProps {
   onOrganize: () => void;
   onSave: () => void;
   onLoad: (flow: { nodes: Node[]; edges: Edge[] }) => void;
+  onDelete: () => void;
 }
 
-export function Sidebar({ onOrganize, onSave, onLoad }: SidebarProps) {
+export function Sidebar({ onOrganize, onSave, onLoad, onDelete }: SidebarProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const onDragStart = (event: React.DragEvent, nodeType: string) => {
@@ -50,6 +51,7 @@ export function Sidebar({ onOrganize, onSave, onLoad }: SidebarProps) {
         onChange={handleFileChange}
         style={{ display: 'none' }}
       />
+      <SidebarButton label="Deletar Selecionados" icon={Trash} onClick={onDelete} />
       <SidebarNodeItem nodeType="start" label="Início" icon={Play} onDragStart={onDragStart} />
       <SidebarNodeItem nodeType="decision" label="Decisão" icon={GitBranch} onDragStart={onDragStart} />
       <SidebarNodeItem nodeType="alcada" label="Alçada" icon={Shield} onDragStart={onDragStart} />


### PR DESCRIPTION
## Summary
- prevent decision nodes from having more than one outgoing connection
- add sidebar button and keyboard shortcuts to delete selected nodes and edges

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb482c0190832f86a4db5be0516626