### PR TITLE
Persist decision and alçada values in flow exports

### DIFF
--- a/components/flow/FlowBuilder.tsx
+++ b/components/flow/FlowBuilder.tsx
@@ -19,7 +19,7 @@ import { Sidebar } from './Sidebar';
 import { StartNode } from './nodes/StartNode';
 import { EndNode } from './nodes/EndNode';
 import { DecisionNode } from './nodes/DecisionNode';
-import { DecisionType } from '../../types/decision';
+import { DecisionType, RiskLevel } from '../../types/decision';
 import { AlcadaNode } from './nodes/AlcadaNode';
 
 const nodeTypes = { start: StartNode, end: EndNode, decision: DecisionNode, alcada: AlcadaNode };
@@ -126,6 +126,7 @@ export default function FlowBuilder() {
                   ? 'Decisão'
                   : 'Alçada',
           decisionType: type === 'decision' ? DecisionType.RISCO : undefined,
+          riskLevel: type === 'decision' ? RiskLevel.MEDIO : undefined,
           levels: type === 'alcada' ? [] : undefined,
         },
       };

--- a/components/flow/nodes/AlcadaNode.tsx
+++ b/components/flow/nodes/AlcadaNode.tsx
@@ -10,7 +10,9 @@ export function AlcadaNode({ data }: NodeProps<AlcadaData>) {
   const adicionar = () => {
     if (lista.length >= 5) return;
     if (lista.includes(selecionado)) return;
-    setLista([...lista, selecionado]);
+    const novaLista = [...lista, selecionado];
+    setLista(novaLista);
+    data.levels = novaLista;
   };
 
   const mover = (from: number, to: number) => {
@@ -19,12 +21,17 @@ export function AlcadaNode({ data }: NodeProps<AlcadaData>) {
       const item = copy[from];
       copy.splice(from, 1);
       copy.splice(to, 0, item);
+      data.levels = copy;
       return copy;
     });
   };
 
   const remover = (index: number) => {
-    setLista((curr) => curr.filter((_, i) => i !== index));
+    setLista((curr) => {
+      const copy = curr.filter((_, i) => i !== index);
+      data.levels = copy;
+      return copy;
+    });
   };
 
   return (

--- a/components/flow/nodes/DecisionNode.tsx
+++ b/components/flow/nodes/DecisionNode.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, ChangeEvent } from 'react';
 import { Handle, NodeProps, Position } from 'reactflow';
 import { DecisionData, DecisionType, RiskLevel } from '../../../types/decision';
 import { GitBranch } from 'lucide-react';
@@ -8,6 +8,36 @@ export function DecisionNode({ data }: NodeProps<DecisionData>) {
   const [risk, setRisk] = useState<RiskLevel>(data.riskLevel || RiskLevel.MEDIO);
   const [from, setFrom] = useState<number | undefined>(data.from);
   const [to, setTo] = useState<number | undefined>(data.to);
+
+  const handleTypeChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const newType = e.target.value as DecisionType;
+    setType(newType);
+    data.decisionType = newType;
+    if (newType === DecisionType.RISCO) {
+      data.from = undefined;
+      data.to = undefined;
+    } else {
+      data.riskLevel = undefined;
+    }
+  };
+
+  const handleRiskChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const newRisk = e.target.value as RiskLevel;
+    setRisk(newRisk);
+    data.riskLevel = newRisk;
+  };
+
+  const handleFromChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value ? Number(e.target.value) : undefined;
+    setFrom(value);
+    data.from = value;
+  };
+
+  const handleToChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value ? Number(e.target.value) : undefined;
+    setTo(value);
+    data.to = value;
+  };
 
   return (
     <div
@@ -24,7 +54,7 @@ export function DecisionNode({ data }: NodeProps<DecisionData>) {
         {data.label || 'Decisão'}
       </div>
       <div style={{ marginTop: 4 }}>
-        <select value={type} onChange={(e) => setType(e.target.value as DecisionType)}>
+        <select value={type} onChange={handleTypeChange}>
           <option value={DecisionType.RISCO}>Tipo de risco</option>
           <option value={DecisionType.ENDIVIDAMENTO}>Valor de endividamento</option>
           <option value={DecisionType.PROPOSTA}>Valor da proposta</option>
@@ -32,7 +62,7 @@ export function DecisionNode({ data }: NodeProps<DecisionData>) {
       </div>
       {type === DecisionType.RISCO && (
         <div style={{ marginTop: 4 }}>
-          <select value={risk} onChange={(e) => setRisk(e.target.value as RiskLevel)}>
+          <select value={risk} onChange={handleRiskChange}>
             <option value={RiskLevel.ALTO}>Alto</option>
             <option value={RiskLevel.MEDIO}>Médio</option>
             <option value={RiskLevel.BAIXO}>Baixo</option>
@@ -45,14 +75,14 @@ export function DecisionNode({ data }: NodeProps<DecisionData>) {
             type="number"
             placeholder="de"
             value={from ?? ''}
-            onChange={(e) => setFrom(e.target.value ? Number(e.target.value) : undefined)}
+            onChange={handleFromChange}
             style={{ width: 60, marginRight: 4 }}
           />
           <input
             type="number"
             placeholder="até"
             value={to ?? ''}
-            onChange={(e) => setTo(e.target.value ? Number(e.target.value) : undefined)}
+            onChange={handleToChange}
             style={{ width: 60 }}
           />
         </div>


### PR DESCRIPTION
## Summary
- Persist Decision node fields by syncing component state with node data
- Persist Alçada node levels by storing list in node data
- Include default risk level for new Decision nodes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb4b29aa24832f95f314d94bb01848