### PR TITLE
Add proposal amount column to BPMN spreadsheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Aplicação Next.js da Mesa de Crédito com suporte a um backend Python modular.
   - Ajuste esse arquivo caso precise incluir novos plugins ou customizações ligadas ao Tailwind CSS.
 - Conversão de BPMN para planilha:
   - No construtor de fluxos (página inicial) utilize o botão **Gerar Planilha (BPMN)** na barra lateral.
-  - Selecione um arquivo `.bpmn` ou `.xml`. O sistema analisa as condições de risco e faixas de proposta e baixa um arquivo CSV separado por vírgula no formato `Valor de Endividamento,Score,Assistente PA,Consultor PA,Gerente Relacionamento PA,Assistente SRO,Analista I Sede,Analista II Sede,Supervisor Crédito,Coordenador Sede,Gerente Regional,Gerente Sede,Superintendente,Diretor Sede,Diretor Executivo`.
+  - Selecione um arquivo `.bpmn` ou `.xml`. O sistema analisa as condições de risco e faixas de proposta e baixa um arquivo CSV separado por vírgula no formato `Valor de Endividamento,Valor da Proposta,Score,Assistente PA,Consultor PA,Gerente Relacionamento PA,Assistente SRO,Analista I Sede,Analista II Sede,Supervisor Crédito,Coordenador Sede,Gerente Regional,Gerente Sede,Superintendente,Diretor Sede,Diretor Executivo`.
   - O arquivo considera as combinações de risco (baixo, médio e alto) e as faixas configuradas no script BPMN para apontar quais grupos participam das aprovações. Entradas marcadas com `x*` indicam grupos de alçada em que qualquer um dos papéis listados na sequência pode atuar.
 
 ## Backend Python

--- a/python/README.md
+++ b/python/README.md
@@ -31,6 +31,9 @@ Após instalar as dependências, os comandos abaixo ficam disponíveis:
 ## Conversão de BPMN em planilhas
 - `PYTHONPATH=src python -m bpmn_to_planilha <arquivo.bpmn> <saida.csv>`: gera a
   planilha de alçadas com base em um processo BPMN compatível com Activiti.
+  O cabeçalho segue o padrão
+  `Valor de Endividamento/Valor da Proposta/Score/Assistente PA/...` e inclui a
+  coluna de valor representativo da proposta.
 
 Um exemplo completo do fluxo **FluxoCiviaCartaoCreditoLimiteCredito** está em
 `python/examples/`. Execute o comando abaixo (com o ambiente virtual ativado) para

--- a/python/src/bpmn_to_planilha.py
+++ b/python/src/bpmn_to_planilha.py
@@ -11,8 +11,8 @@ Uso rápido:
 
 O arquivo de saída seguirá o padrão descrito pelo time de negócios:
 ```
-Valor de Endividamento/Score/Assistente PA/Consultor PA/Gerente Relacionamento PA/Assistente SRO/Analista I Sede/Analista II Sede/Supervisor Crédito/Coordenador Sede/Gerente Regional/Gerente Sede/Superintendente/Diretor Sede/Diretor Executivo
-até 50 mil/Baixo///x/x////////
+Valor de Endividamento/Valor da Proposta/Score/Assistente PA/Consultor PA/Gerente Relacionamento PA/Assistente SRO/Analista I Sede/Analista II Sede/Supervisor Crédito/Coordenador Sede/Gerente Regional/Gerente Sede/Superintendente/Diretor Sede/Diretor Executivo
+até 50 mil/40000/Baixo///x/x////////
 ```
 """
 from __future__ import annotations
@@ -362,6 +362,7 @@ def gerar_planilha(definition: BpmnDefinition) -> List[List[str]]:
             linhas.append(
                 [
                     intervalo_label,
+                    str(int(valor) if float(valor).is_integer() else valor),
                     risco_label,
                     "x" if papeis["Assistente PA"] else "",
                     "x" if papeis["Consultor PA"] else "",
@@ -384,6 +385,7 @@ def gerar_planilha(definition: BpmnDefinition) -> List[List[str]]:
 def escrever_csv_saida(rows: Sequence[Sequence[str]], output_path: Path) -> None:
     header = [
         "Valor de Endividamento",
+        "Valor da Proposta",
         "Score",
         "Assistente PA",
         "Consultor PA",

--- a/tests/bpmnSpreadsheet.test.ts
+++ b/tests/bpmnSpreadsheet.test.ts
@@ -277,6 +277,7 @@ describe('generateApprovalMatrix', () => {
       (row) => row.valorEndividamento === 'até 50 mil' && row.score === 'Baixo'
     );
     expect(baixoAte50).toBeDefined();
+    expect(baixoAte50?.valorProposta).toBe('40000');
     expect(baixoAte50?.assistenteSRO).toBe('x');
     expect(baixoAte50?.analistaISede).toBe('x');
     expect(baixoAte50?.sequenceGroupByColumn.assistenteSRO).toBe(
@@ -317,9 +318,10 @@ describe('generateApprovalMatrix', () => {
     const content = rowsToDelimitedContent(rows);
     const lines = content.split('\n');
     expect(lines[0]).toBe(
-      'Valor de Endividamento,Score,Assistente PA,Consultor PA,Gerente Relacionamento PA,Assistente SRO,Analista I Sede,Analista II Sede,Supervisor Crédito,Coordenador Sede,Gerente Regional,Gerente Sede,Superintendente,Diretor Sede,Diretor Executivo'
+      'Valor de Endividamento,Valor da Proposta,Score,Assistente PA,Consultor PA,Gerente Relacionamento PA,Assistente SRO,Analista I Sede,Analista II Sede,Supervisor Crédito,Coordenador Sede,Gerente Regional,Gerente Sede,Superintendente,Diretor Sede,Diretor Executivo'
     );
     expect(lines[1]).toContain('até 50 mil');
+    expect(lines[1]).toContain('40000');
     expect(content).not.toContain('*');
   });
 

--- a/utils/bpmnSpreadsheet.ts
+++ b/utils/bpmnSpreadsheet.ts
@@ -1,5 +1,6 @@
 export interface SpreadsheetRow {
   valorEndividamento: string;
+  valorProposta: string;
   score: string;
   assistentePA: string;
   consultorPA: string;
@@ -65,7 +66,7 @@ const VALUE_RANGES: ValueRange[] = [
 
 const RISK_LEVELS: RiskLevel[] = ['BAIXO', 'MEDIO', 'ALTO'];
 
-type GroupColumnKey = Exclude<keyof SpreadsheetRow, 'valorEndividamento' | 'score'>;
+type GroupColumnKey = Exclude<keyof SpreadsheetRow, 'valorEndividamento' | 'valorProposta' | 'score'>;
 
 export type SequenceGroupIndexMap = Partial<Record<GroupColumnKey, number>>;
 
@@ -135,6 +136,7 @@ GROUP_COLUMN_CONFIG.forEach(({ key, groups }) => {
 
 export const SPREADSHEET_COLUMNS: Array<{ key: keyof SpreadsheetRow; label: string }> = [
   { key: 'valorEndividamento', label: 'Valor de Endividamento' },
+  { key: 'valorProposta', label: 'Valor da Proposta' },
   { key: 'score', label: 'Score' },
   ...GROUP_COLUMN_CONFIG.map(({ key, label }) => ({ key, label })),
 ];
@@ -463,6 +465,7 @@ function groupsToRow(
 
   const row: ApprovalMatrixRow = {
     valorEndividamento: range.label,
+    valorProposta: String(range.representativeValue),
     score: formatScoreLabel(risk),
     assistentePA: '',
     consultorPA: '',


### PR DESCRIPTION
## Summary
- adiciona a coluna "Valor da Proposta" na geração de planilhas de alçada tanto no utilitário Next.js quanto no conversor Python
- atualiza os testes automatizados e a documentação para refletir o novo cabeçalho da planilha

## Testing
- npm test
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138b7cdef8833397b57d497b6a192d)